### PR TITLE
repo: add engine lock and useful infos inside package file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,8 @@
 {
-  "name": "@antora/ui-default",
-  "requires": true,
+  "name": "nuvolaris-documentation-ui",
+  "version": "0.1.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "@ampproject/remapping": {
       "version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -1,14 +1,25 @@
 {
-  "name": "@antora/ui-default",
-  "description": "An archetype project that produces a UI for creating documentation sites with Antora",
-  "homepage": "https://gitlab.com/antora/antora-ui-default",
+  "name": "nuvolaris-documentation-ui",
+  "description": "Documentation UI for Nuvolaris project.",
+  "version": "0.1.0",
+  "author": "nuvolaris",
+  "keywords": [
+    "nuvolaris",
+    "documentation",
+    "antora",
+    "ui"
+  ],
+  "homepage": "https://nuvolaris.github.io",
   "license": "MPL-2.0",
   "repository": {
     "type": "git",
-    "url": "https://gitlab.com/antora/antora-ui-default.git"
+    "url": "https://gitlab.com/nuvolaris/nuvolaris-documentation-ui.git"
+  },
+  "bugs": {
+    "url": "https://github.com/nuvolaris/nuvolaris-bugs/issues"
   },
   "engines": {
-    "node": ">= 8.0.0"
+    "node": "^10.0.0"
   },
   "browserslist": [
     "last 2 versions"


### PR DESCRIPTION
Adds node engine version lock to avoid incompatibilities and useful info inside `package.json`, such as bug tracking links and more.